### PR TITLE
set preferable (max) resolution and other fixes

### DIFF
--- a/resources/language/english/strings.xml
+++ b/resources/language/english/strings.xml
@@ -51,6 +51,14 @@
     <string id="30052">Ensure that your username and password are set in settings.</string>
     <string id="30053">Only Email login is supported (no Facebook, no Google).</string>
     <string id="30054">List files according to</string>
+	
+	<!-- BEGIN added by JoKeRzBoX -->
+	<string id="30055">Maximum resolution for Video playback</string>
+	<string id="30056">Maximum resolution for Audio playback</string>
+	<string id="30057">original|720p|480p|360p|240p|ask</string>
+	<string id="30058">original|320k|128k|32k|ask</string>
+	<!-- END added by JoKeRzBoX -->
+	
     <string id="30060">Library</string>
     <string id="30061">Library Integration via Google Drive</string>
     <string id="30062">Full Username (i.e. username@gmail.com)</string>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -12,15 +12,20 @@
         <setting id="cache_folder" type="folder" label="30012" visible="eq(-1,1)" default="special://profile/addon_data/plugin.video.hive/cache"/>
         <setting type="lsep"/>
         <setting id="playback_links" type="bool" label="30013" default="true"/>-->
+    </category>
+    <category label="30009">
         <setting label="30083" type="lsep"/>
-        <setting id="playback_type" type="enum" label="30006" values="Always original quality|Transcode|Always ask" default="0"/>
+<!--        <setting id="playback_type" type="enum" label="30006" values="Always original quality|Transcode|Always ask" default="0"/>-->
+        <setting id="playback_type_video" type="enum" label="30055" values="Always original quality|720p|480p|360p|240p|Always ask" default="0"/>
+        <setting id="playback_type_audio" type="enum" label="30056" values="Always original quality|320k|128k|32k|Always ask" default="0"/>
         <setting id="hide_unwatchable" type="bool" label="30085" default="false"/>
         <setting label="30084" type="lsep"/>
-        <setting id="free_playback_type" type="enum" label="30006" values="Always original quality|240p|Always ask" default="1"/>
+        <setting id="free_playback_type_video" type="enum" label="30055" values="Always original quality|240p|Always ask" default="1"/>
+        <setting id="free_playback_type_audio" type="enum" label="30056" values="Always original quality|32k|Always ask" default="0"/>
         <setting id="free_hide_unwatchable" type="bool" label="30085" default="true"/>
 
     </category>
-<!-->    <category label="30060">
+<!--    <category label="30060">
         <setting label="30061" type="lsep"/>
         <setting id="gdrive_library" type="bool" label="30064" default="false" />
         <setting id="gdrive_username" type="text" label="30062" default="" />
@@ -29,16 +34,6 @@
         <setting id="gdrive_save_auth_token" type="bool" label="30005" default="true" />
     </category>
 -->
-    <category label="30074">
-        <setting id="crashreport_enable" type="bool" label="30075" default="false"/>
-        <setting id="crashreport_email" type="text" label="30076" default=""/>
-        <setting id="crashreport_os" type="enum" label="30078" values="Other|Windows|Linux|Raspberry PI|Android|iOS|Mac OS|Apple TV"/>
-        <setting id="crashreport_version"  type="enum" label="30079" values="Other|XBMC 12|XBMC 13|XBMC 13.2|KODI 14|KODI 14 alpha1|KODI alpha2|KODI 14 beta"/>
-        <setting label="30077" type="lsep"/>
-        <setting label="30071" type="lsep"/>
-        <setting label="30072" type="lsep"/>
-        <setting id="crashreport_ident"  type="text" label="30080" />
-    </category>
     <category label="30065">
         <setting label="30066" type="lsep"/>
         <setting id="context_photo" type="enum" subsetting="true" label="30068" values="Photos only|Music and Photos|Everything" default="0"/>
@@ -101,5 +96,15 @@
         <setting id="hive10_password" type="text" label="30002" visible="eq(-38,9)" option="hidden" default="" />
         <setting id="hive10_save_auth_token" type="bool" label="30005" visible="eq(-39,9)" default="true" />
         <setting id="hive10_type" type="enum" label="30082" visible="eq(-40,9)" values="non-premium or free|premium" default="0" />
+    </category>
+    <category label="30074">
+        <setting id="crashreport_enable" type="bool" label="30075" default="false"/>
+        <setting id="crashreport_email" type="text" label="30076" default=""/>
+        <setting id="crashreport_os" type="enum" label="30078" values="Other|Windows|Linux|Raspberry PI|Android|iOS|Mac OS|Apple TV"/>
+        <setting id="crashreport_version"  type="enum" label="30079" values="Other|XBMC 12|XBMC 13|XBMC 13.2|KODI 14|KODI 14 alpha1|KODI alpha2|KODI 14 beta"/>
+        <setting label="30077" type="lsep"/>
+        <setting label="30071" type="lsep"/>
+        <setting label="30072" type="lsep"/>
+        <setting id="crashreport_ident"  type="text" label="30080" />
     </category>
 </settings>


### PR DESCRIPTION
- FIX: the "ask" dialogue where addon asks user what resolution to choose
  is now ordered (from higher to lower resolution)
- FIX: in the "ask" dialogue, if user just closes the dialogue without
choosing anything, video would still try to play.
- ADD: Settings to configure the max quality/resolution for video and
 audio (separate) for both premium and free users
- ADD: When video plays, title also shows the resolution (<VIDEO
NAME> @ <RES>)