### PR TITLE
Clear strms

### DIFF
--- a/default.py
+++ b/default.py
@@ -983,10 +983,34 @@ elif mode == 'streamurl':
 
     xbmcplugin.setResolvedUrl(int(sys.argv[1]), True, item)
 
+#clear strm files
+elif mode == 'clearstrm':
+    returnPrompt = xbmcgui.Dialog().yesno(addon.getLocalizedString(30000), addon.getLocalizedString(30091))
+    if returnPrompt:
+        import shutil
+        strm_path = addon.getSetting('strm_path')
+        movies_path = addon.getSetting('movies_path')
+        tvshows_path = addon.getSetting('tvshows_path')
+        try:
+            shutil.rmtree(xbmc.translatePath(strm_path))
+        except: pass
 
-if mode == 'options' or mode == 'buildstrm' or mode == 'clearauth':
+        try:
+            shutil.rmtree(xbmc.translatePath(movies_path))
+        except: pass
+
+        try:
+            shutil.rmtree(xbmc.translatePath(tvshows_path))
+        except: pass
+
+        returnPrompt = xbmcgui.Dialog().yesno(addon.getLocalizedString(30000), addon.getLocalizedString(30092))
+        if returnPrompt:
+            xbmc.executebuiltin('CleanLibrary(video)')
+
+if mode == 'options' or mode == 'buildstrm' or mode == 'clearauth' or mode == 'clearstrm':
     addMenu(PLUGIN_URL+'?mode=clearauth','<<'+addon.getLocalizedString(30018)+'>>')
     addMenu(PLUGIN_URL+'?mode=buildstrm','<<'+addon.getLocalizedString(30025)+'>>')
+    addMenu(PLUGIN_URL+'?mode=clearstrm','<<'+addon.getLocalizedString(30090)+'>>')
     addMenu(PLUGIN_URL+'?mode=createsearch','<<Save Search>>')
 
 

--- a/default.py
+++ b/default.py
@@ -988,20 +988,22 @@ elif mode == 'clearstrm':
     returnPrompt = xbmcgui.Dialog().yesno(addon.getLocalizedString(30000), addon.getLocalizedString(30091))
     if returnPrompt:
         import shutil
-        strm_path = addon.getSetting('strm_path')
-        movies_path = addon.getSetting('movies_path')
-        tvshows_path = addon.getSetting('tvshows_path')
-        try:
-            shutil.rmtree(xbmc.translatePath(strm_path))
-        except: pass
 
-        try:
-            shutil.rmtree(xbmc.translatePath(movies_path))
-        except: pass
+        delpath_list = [
+                addon.getSetting('strm_path'),
+                addon.getSetting('movies_path'),
+                addon.getSetting('tvshows_path')
+            ]
 
-        try:
-            shutil.rmtree(xbmc.translatePath(tvshows_path))
-        except: pass
+        for delpath in delpath_list:
+            if delpath != '':
+                try:
+                    for root, dirs, files in os.walk(delpath):
+                        for f in files:
+                            os.unlink(os.path.join(root, f))
+                        for d in dirs:
+                            shutil.rmtree(os.path.join(root, d))
+                except: pass
 
         returnPrompt = xbmcgui.Dialog().yesno(addon.getLocalizedString(30000), addon.getLocalizedString(30092))
         if returnPrompt:

--- a/default.py
+++ b/default.py
@@ -775,7 +775,7 @@ elif mode == 'video' or mode == 'audio':
         service
     except NameError:
         xbmcgui.Dialog().ok(addon.getLocalizedString(30000), addon.getLocalizedString(30051), addon.getLocalizedString(30052), addon.getLocalizedString(30053))
-        log(aaddon.getLocalizedString(30050)+ 'hive-login', True)
+        log(addon.getLocalizedString(30050)+ 'hive-login', True)
         xbmcplugin.endOfDirectory(plugin_handle)
 
     playbackType = 0
@@ -887,7 +887,7 @@ elif mode == 'requestencoding':
             service
     except NameError:
             xbmcgui.Dialog().ok(addon.getLocalizedString(30000), addon.getLocalizedString(30051), addon.getLocalizedString(30052), addon.getLocalizedString(30053))
-            log(aaddon.getLocalizedString(30050)+ 'hive-login', True)
+            log(addon.getLocalizedString(30050)+ 'hive-login', True)
             xbmcplugin.endOfDirectory(plugin_handle)
 
     mediaFile = file.file(filename, title, '', 0, '','')
@@ -914,7 +914,7 @@ elif mode == 'photo':
             service
     except NameError:
             xbmcgui.Dialog().ok(addon.getLocalizedString(30000), addon.getLocalizedString(30051), addon.getLocalizedString(30052), addon.getLocalizedString(30053))
-            log(aaddon.getLocalizedString(30050)+ 'hive-login', True)
+            log(addon.getLocalizedString(30050)+ 'hive-login', True)
             xbmcplugin.endOfDirectory(plugin_handle)
 
 
@@ -972,7 +972,7 @@ elif mode == 'streamurl':
             service
     except NameError:
             xbmcgui.Dialog().ok(addon.getLocalizedString(30000), addon.getLocalizedString(30051), addon.getLocalizedString(30052), addon.getLocalizedString(30053))
-            log(aaddon.getLocalizedString(30050)+ 'hive-login', True)
+            log(addon.getLocalizedString(30050)+ 'hive-login', True)
             xbmcplugin.endOfDirectory(plugin_handle)
 
     url = re.sub('---', '&', url)

--- a/resources/language/english/strings.xml
+++ b/resources/language/english/strings.xml
@@ -93,7 +93,10 @@
 
     <string id="30088">Location to store movie STRMs (optional) </string>
     <string id="30089">Location to store tv show STRMs (optional) </string>
-
+    
+    <string id="30090">Clear STRMs</string>
+    <string id="30091">Do you want to clear all saved STRM files?</string>
+    <string id="30092">Do you want to cleanup your Library?</string>
 
     <string id="30100">This feature is not supported on your version of XBMC / KODI</string>
 


### PR DESCRIPTION
Fixed a typo in default.py and proposing a clear strms option.

I tried using xbmcvfs.exists() but for some weird reason it would not work, so I just did a try: except: case on the rmtrees ... Weird... You might want to rework it, up to you :)

Tested it on OS X and it worked fine, will test on more platforms
